### PR TITLE
update regex to `1.5.5`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ edition = "2018"
 
 [dependencies]
 serde = "1.0.0"
-regex = "1.0.0"
+regex = "1.5.5"
 
 [dev-dependencies]
 serde_derive = "1.0.0"


### PR DESCRIPTION
Updates regex to 1.5.5 as per [security advisory](https://blog.rust-lang.org/2022/03/08/cve-2022-24713.html)